### PR TITLE
Add Login to CLI if User is not Authenticated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1.0.130"
 ncurses = "5.101.0"
 http = "0.2.5"
 rpassword = "5.0"
+users = "0.11.0"
 
 [dependencies.isahc]
 version = "1.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1.0.71"
 serde = "1.0.130"
 ncurses = "5.101.0"
 http = "0.2.5"
+rpassword = "5.0"
 
 [dependencies.isahc]
 version = "1.6.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -81,7 +81,7 @@ impl API {
         for (key, value) in url.query_pairs() {
           if key == "access_token" {
             let value = "Bearer ".to_owned() + &value.to_string();
-            //self.token = Some(value.to_string());
+            self.token = Some(value.to_string());
             return Ok(value.to_string());
           }
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -90,16 +90,11 @@ impl API {
 
   fn login() {
     // Get credentials
-    let mut username = match env::var("CLINK_USERNAME") {
-      Ok(user) => {
-        if user.chars().all(char::is_alphanumeric) {
-          user
-        } else {
-          get_current_username().unwrap().into_string().unwrap()
-        }
-      }
-      Err(_) => get_current_username().unwrap().into_string().unwrap(),
-    };
+    let username: Option<String> = std::env::var("CLINK_USERNAME")
+        .map(|it| Some(it))
+        .unwrap_or_else(|_| get_current_username().and_then(|it| it.into_string().ok()));
+
+    let username: String = username.unwrap();
 
     println!(
      "Please enter password for {}: ",

--- a/src/api.rs
+++ b/src/api.rs
@@ -33,7 +33,9 @@ impl fmt::Display for APIError {
 
 impl API {
   pub fn new() -> API {
-    return API { token: None };
+    let mut api = API { token: None };
+    api.get_token();
+    return api;
   }
   pub fn drop(self: &mut API, machine: String, slot: u8) -> Result<(), Box<dyn std::error::Error>> {
     let token = self.get_token()?;
@@ -79,7 +81,7 @@ impl API {
         for (key, value) in url.query_pairs() {
           if key == "access_token" {
             let value = "Bearer ".to_owned() + &value.to_string();
-            self.token = Some(value.to_string());
+            //self.token = Some(value.to_string());
             return Ok(value.to_string());
           }
         }


### PR DESCRIPTION
Fixes #4 

If user is not authenticated, prompts are made for CSH username and password. These are then piped into a kinit call and restarts the key-grabbing process.