### PR TITLE
Increase clap version to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,22 +68,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
 name = "clink"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "http",
@@ -221,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +247,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -393,6 +401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -545,13 +562,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"
@@ -627,12 +650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,12 +672,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "waker-fn"
@@ -692,6 +703,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,4 @@ serde = "1.0.130"
 ncurses = "5.101.0"
 http = "0.2.5"
 clap = { version = "3.1.6", features = ["cargo"] }
-
-[dependencies.isahc]
-version = "1.6.0"
-features = ["json", "spnego"]
-
-[features]
+isahc = { version = "1.6.0", features = ["json", "spnego"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clink"
-authors = ["Mary Strodl <mstrodl@csh.rit.edu>"]
+authors = ["Mary Strodl <mstrodl@csh.rit.edu>", "Willard Nilges <wilnil@csh.rit.edu>"]
 version = "0.1.1"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 name = "clink"
+authors = ["Mary Strodl <mstrodl@csh.rit.edu>"]
 version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
 url = "2.2.2"
 serde_json = "1.0.71"
 serde = "1.0.130"
 ncurses = "5.101.0"
 http = "0.2.5"
+clap = { version = "3.1.6", features = ["cargo"] }
 
 [dependencies.isahc]
 version = "1.6.0"
 features = ["json", "spnego"]
+
+[features]

--- a/src/commands/drop.rs
+++ b/src/commands/drop.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 
 use crate::api::API;
 
-pub fn drop(matches: &ArgMatches<'_>, api: &mut API) -> Result<(), Box<dyn std::error::Error>> {
+pub fn drop(matches: &ArgMatches, api: &mut API) -> Result<(), Box<dyn std::error::Error>> {
   // We can unwrap these because they're required arguments:
   let machine = matches.value_of("machine").unwrap();
   let slot = matches.value_of("slot").unwrap();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use crate::api::APIError;
 use crate::api::API;
 
-pub fn list(matches: &ArgMatches<'_>, api: &mut API) -> Result<(), Box<dyn std::error::Error>> {
+pub fn list(matches: &ArgMatches, api: &mut API) -> Result<(), Box<dyn std::error::Error>> {
   let token = api.get_token()?;
 
   let client = HttpClient::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{command, Arg, ArgMatches, Command};
 
 pub mod api;
 pub mod commands;
@@ -6,31 +6,29 @@ pub mod commands;
 mod ui;
 
 fn main() {
-  let matches = App::new("CLI Drink")
-    .version("0.1.1")
-    .author("Mary Strodl <mstrodl@csh.rit.edu>")
+  let matches = command!("CLI Drink")
     .about("Drops drinks from CSH vending machines")
     .subcommand(
-      SubCommand::with_name("list")
+      Command::new("list")
         .about("Display available slots")
         .arg(
-          Arg::with_name("machine")
+          Arg::new("machine")
             .index(1)
             .help("Which machine should be listed?")
             .required(false),
         ),
     )
     .subcommand(
-      SubCommand::with_name("drop")
+      Command::new("drop")
         .about("Drops a drink")
         .arg(
-          Arg::with_name("machine")
+          Arg::new("machine")
             .index(1)
             .help("Machine to drop from")
             .required(true),
         )
         .arg(
-          Arg::with_name("slot")
+          Arg::new("slot")
             .index(2)
             .help("Slot to drop from")
             .required(true),


### PR DESCRIPTION
This way we can use clap::command!() and get information about the version from the Cargo.toml file.